### PR TITLE
Add optional `equalityFn` to TypedUseSelector

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,9 +83,10 @@ export type UseSelector<State, Selected> = (
  * e.g.
  * export const useSelector: TypedUseSelector<State> = _useSelector;
  */
-export type TypedUseSelector<State> = <Selected>(
-  selector: (state: State) => Selected
-) => Selected;
+type TypedUseSelector<TState> = <TSelected>(
+  selector: (state: TState) => TSelected,
+  equalityFn?: (left: TSelected, right: TSelected) => boolean
+) => TSelected;
 
 type EqualityFn = (a: any, b: any) => any;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ export type UseSelector<State, Selected> = (
  * e.g.
  * export const useSelector: TypedUseSelector<State> = _useSelector;
  */
-type TypedUseSelector<TState> = <TSelected>(
+export type TypedUseSelector<TState> = <TSelected>(
   selector: (state: TState) => TSelected,
   equalityFn?: (left: TSelected, right: TSelected) => boolean
 ) => TSelected;


### PR DESCRIPTION
This is basically to be on par with `react-redux` typings:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/50adc95acf873e714256074311353232fcc1b5ed/types/react-redux/index.d.ts#L558